### PR TITLE
Preparing data in preprocessing for SC segmentation task

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,27 @@ git clone https://github.com/ivadomed/model_seg_ms_mp2rage.git
  
 ## Prepare the data
 
-The data need to be preprocessed before training. Here is the syntax: 
+The data need to be preprocessed before training. The general syntax for preprocessing is:
 
 ~~~
-sct_run_batch -script <PATH_TO_REPOSITORY>/model_seg_ms_mp2rage/preprocessing/preprocess_data.sh -path-data <PATH_TO_DATA>/basel-mp2rage/ -path-output <PATH_OUTPUT> -script-args "<CENTERLINE_METHOD>" -jobs <JOBS>
+sct_run_batch -script <PATH_TO_REPOSITORY>/model_seg_ms_mp2rage/preprocessing/preprocess_data.sh -path-data <PATH_TO_DATA>/basel-mp2rage/ -path-output <PATH_OUTPUT> -script-args "-centerline_method <CENTERLINE_METHOD> -task <TASK>" -jobs <JOBS>
 ~~~
 
-where `<CENTERLINE_METHOD>` is either `svm` or `cnn`. You can also leave out the `-script-args` argument in which case `cnn` will be used by default in the preprocessing script.
-[#10](https://github.com/ivadomed/model_seg_ms_mp2rage/issues/10) is a related issue you can check.
+where `<CENTERLINE_METHOD>` is either `cnn` (default value) or `svm` and 
+`<TASK>` is either `lesionseg` (default value) or `scseg`. You can leave the `-script-args` 
+argument empty to stick to the default values.
+
+To run preprocessing for the lesion segmentation task:
+
+~~~
+sct_run_batch -script <PATH_TO_REPOSITORY>/model_seg_ms_mp2rage/preprocessing/preprocess_data.sh -path-data <PATH_TO_DATA>/basel-mp2rage/ -path-output basel-mp2rage-preprocessed-lesionseg -script-args "svm lesionseg" -jobs <JOBS>
+~~~
+
+To run preprocessing for the spinal cord (SC) segmentation task:
+
+~~~
+sct_run_batch -script <PATH_TO_REPOSITORY>/model_seg_ms_mp2rage/preprocessing/preprocess_data.sh -path-data <PATH_TO_DATA>/basel-mp2rage/ -path-output basel-mp2rage-preprocessed-scseg -script-args "svm scseg" -jobs <JOBS>
+~~~
 
 After running the preprocessing, you can also run the quality-control (QC) script:
 ```

--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ where `<CENTERLINE_METHOD>` is either `cnn` (default value) or `svm` and
 `<TASK>` is either `lesionseg` (default value) or `scseg`. You can leave the `-script-args` 
 argument empty to stick to the default values.
 
-To run preprocessing for the lesion segmentation task:
-
-~~~
-sct_run_batch -script <PATH_TO_REPOSITORY>/model_seg_ms_mp2rage/preprocessing/preprocess_data.sh -path-data <PATH_TO_DATA>/basel-mp2rage/ -path-output basel-mp2rage-preprocessed-lesionseg -script-args "svm lesionseg" -jobs <JOBS>
-~~~
-
 To run preprocessing for the spinal cord (SC) segmentation task:
 
 ~~~
 sct_run_batch -script <PATH_TO_REPOSITORY>/model_seg_ms_mp2rage/preprocessing/preprocess_data.sh -path-data <PATH_TO_DATA>/basel-mp2rage/ -path-output basel-mp2rage-preprocessed-scseg -script-args "svm scseg" -jobs <JOBS>
+~~~
+
+To run preprocessing for the lesion segmentation task:
+
+~~~
+sct_run_batch -script <PATH_TO_REPOSITORY>/model_seg_ms_mp2rage/preprocessing/preprocess_data.sh -path-data <PATH_TO_DATA>/basel-mp2rage/ -path-output basel-mp2rage-preprocessed-lesionseg -script-args "svm lesionseg" -jobs <JOBS>
 ~~~
 
 After running the preprocessing, you can also run the quality-control (QC) script:

--- a/preprocessing/preprocess_data.sh
+++ b/preprocessing/preprocess_data.sh
@@ -213,7 +213,6 @@ elif [[ $TASK == "scseg" ]]; then
     datetime=$(date +'%Y-%m-%d %H:%M:%S')
     echo -e "{\n    \"Author\": \"Generated with sct_deepseg_sc\",\n    \"Date\": \"${datetime}\"\n}" >> $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json
   fi
-
 else
   echo "Task = ${TASK} is not recognized!"
   exit 1

--- a/preprocessing/preprocess_data.sh
+++ b/preprocessing/preprocess_data.sh
@@ -205,8 +205,14 @@ elif [[ $TASK == "scseg" ]]; then
   mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives $PATH_DATA_PROCESSED_CLEAN/derivatives/labels $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/
   file_seg_gt="${file}_seg-manual"
   rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}_seg.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.nii.gz
-  # TODO: Get the correct JSON below, skipping for now.
-  rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt1}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json
+  # Copy the relevant JSON: use auto-generated JSON for manually corrected and create new JSON for sct_deepseg_sc generated SC segs
+  if [[ -f $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json ]]; then
+    rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json
+  else
+    datetime=$(date +'%Y-%m-%d %H:%M:%S')
+    echo -e "{\n\t\"Author\": \"Generated with sct_deepseg_sc\",\n\t\"Date\": \"${datetime}\"\n}" >> $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json
+  fi
+
 else
   echo "Task = ${TASK} is not recognized!"
   exit 1

--- a/preprocessing/preprocess_data.sh
+++ b/preprocessing/preprocess_data.sh
@@ -209,7 +209,9 @@ elif [[ $TASK == "scseg" ]]; then
   if [[ -f $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json ]]; then
     rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json
   else
+    # Get current datetime and set tabs to 4 spaces
     datetime=$(date +'%Y-%m-%d %H:%M:%S')
+    tabs 4
     echo -e "{\n\t\"Author\": \"Generated with sct_deepseg_sc\",\n\t\"Date\": \"${datetime}\"\n}" >> $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json
   fi
 

--- a/preprocessing/preprocess_data.sh
+++ b/preprocessing/preprocess_data.sh
@@ -211,8 +211,7 @@ elif [[ $TASK == "scseg" ]]; then
   else
     # Get current datetime and set tabs to 4 spaces
     datetime=$(date +'%Y-%m-%d %H:%M:%S')
-    tabs 4
-    echo -e "{\n\t\"Author\": \"Generated with sct_deepseg_sc\",\n\t\"Date\": \"${datetime}\"\n}" >> $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json
+    echo -e "{\n    \"Author\": \"Generated with sct_deepseg_sc\",\n    \"Date\": \"${datetime}\"\n}" >> $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json
   fi
 
 else

--- a/preprocessing/preprocess_data.sh
+++ b/preprocessing/preprocess_data.sh
@@ -6,10 +6,11 @@
 # - SCT (5.4.0)
 #
 # Usage:
-#   ./preprocess_data.sh <SUBJECT> <CENTERLINE_METHOD>
+#   ./preprocess_data.sh <SUBJECT> <CENTERLINE_METHOD> <TASK>
 #
 # <SUBJECT> is the name of the subject in BIDS convention (sub-XXX)
 # <CENTERLINE_METHOD> is the method sct_deepseg_sc uses for centerline extraction (cnn or svm)
+# <TASK> is the aimed training task which will guide preprocessing (scseg or lesionseg)
 #
 # Manual segmentations or labels should be located under:
 # PATH_DATA/derivatives/labels/SUBJECT/<CONTRAST>/
@@ -70,6 +71,7 @@ segment_if_does_not_exist() {
 # Retrieve input params and other params
 SUBJECT=$1
 CENTERLINE_METHOD=${2:-"cnn"}
+TASK=${3:-"lesionseg"}
 
 # get starting time:
 start=`date +%s`
@@ -174,23 +176,43 @@ cd $PATH_OUTPUT
 
 # Create and populate clean data processed folder for training
 PATH_DATA_PROCESSED_CLEAN="${PATH_DATA_PROCESSED}_clean"
+
+# Copy over required BIDs files
 mkdir -p $PATH_DATA_PROCESSED_CLEAN $PATH_DATA_PROCESSED_CLEAN/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat
 rsync -avzh $PATH_DATA_PROCESSED/dataset_description.json $PATH_DATA_PROCESSED_CLEAN/
 rsync -avzh $PATH_DATA_PROCESSED/participants.* $PATH_DATA_PROCESSED_CLEAN/
 rsync -avzh $PATH_DATA_PROCESSED/README $PATH_DATA_PROCESSED_CLEAN/
-rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.nii.gz
-rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}.json $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.json
-mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives $PATH_DATA_PROCESSED_CLEAN/derivatives/labels $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/
-rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt1}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt1}.nii.gz
-rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt1}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt1}.json
-# If second rater is present, copy the other files
-if [[ -f ${PATH_DATA_PROCESSED}/derivatives/labels/${SUBJECT}/anat/${file_gt2}.nii.gz ]]; then
-  # Copy the second rater GT and aggregated GTs if second rater is present
-  rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt2}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt2}.nii.gz
-  rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt2}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt2}.json
-  rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gtc}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gtc}.nii.gz
-  rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_soft}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_soft}.nii.gz
+
+if [[ $TASK == "lesionseg" ]]; then
+  # For lesion segmentation task, copy SC crops as inputs and lesion annotations as targets
+  rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.nii.gz
+  rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}.json $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.json
+  mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives $PATH_DATA_PROCESSED_CLEAN/derivatives/labels $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/
+  rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt1}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt1}.nii.gz
+  rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt1}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt1}.json
+  # If second rater is present, copy the other files
+  if [[ -f ${PATH_DATA_PROCESSED}/derivatives/labels/${SUBJECT}/anat/${file_gt2}.nii.gz ]]; then
+    # Copy the second rater GT and aggregated GTs if second rater is present
+    rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt2}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt2}.nii.gz
+    rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt2}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gt2}.json
+    rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gtc}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_gtc}.nii.gz
+    rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_soft}_crop.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_soft}.nii.gz
+  fi
+elif [[ $TASK == "scseg" ]]; then
+  # For SC segmentation task, copy raw subject images as inputs and SC masks as targets
+  rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}.nii.gz $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.nii.gz
+  rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}.json $PATH_DATA_PROCESSED_CLEAN/${SUBJECT}/anat/${file}.json
+  mkdir -p $PATH_DATA_PROCESSED_CLEAN/derivatives $PATH_DATA_PROCESSED_CLEAN/derivatives/labels $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT} $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/
+  file_seg_gt="${file}_seg-manual"
+  rsync -avzh $PATH_DATA_PROCESSED/${SUBJECT}/anat/${file}_seg.nii.gz $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.nii.gz
+  # TODO: Get the correct JSON below, skipping for now.
+  rsync -avzh $PATH_DATA_PROCESSED/derivatives/labels/${SUBJECT}/anat/${file_gt1}.json $PATH_DATA_PROCESSED_CLEAN/derivatives/labels/${SUBJECT}/anat/${file_seg_gt}.json
+else
+  echo "Task = ${TASK} is not recognized!"
+  exit 1
 fi
+
+
 
 # Display useful info for the log
 end=`date +%s`


### PR DESCRIPTION
This PR introduces modifications to `preprocess/preprocess_data.sh` to such that it prepares a cleaned data processed folder for carrying out spinal cord (SC) segmentation. More explicitly, a user input argument `<TASK>` is added for specifying whether the preprocessing prepares data for lesion segmentation (`lesionseg`) or SC segmentation (`scseg`). For `scseg`, we copy raw subject images as inputs and SC masks as target labels. More documentation on how to run can be found in the modified `README.md` in this PR.

It is important to note that we have subjects with and without manually-corrected SC segmentations. This means that for some subjects, the ground-truth will be taken as the output of `sct_deepseg_sc`. This might be reasonable because these segmentations were marked "good to go" by @jcohenadad during SCT quality-control.