### PR TITLE
`ivadomed` configs for cascaded pipeline

### DIFF
--- a/config/cascaded.json
+++ b/config/cascaded.json
@@ -1,0 +1,74 @@
+{
+    "command": "test",
+    "gpu_ids": [0],
+    "path_output": "seg_ms_randomrater_output",
+    "model_name": "seg_ms_randomrater_model",
+    "debugging": true,
+    "object_detection_params": {
+        "object_detection_path": "/home/GRAMES.POLYMTL.CA/uzmac/model_seg_ms_mp2rage/seg_sc_output/",
+        "safety_factor": [1.1, 1.1, 1.1]
+    },
+    "loader_parameters": {
+        "path_data": ["basel-mp2rage-preprocessed-lesionseg/data_processed"],
+        "subject_selection": {
+            "n": [],
+            "metadata": [],
+            "value": []
+        },
+        "target_suffix": ["_lesion-manual"],
+        "extensions": [],
+        "roi_params": {
+            "suffix": null,
+            "slice_filter_roi": null
+        },
+        "contrast_params": {
+            "training_validation": ["UNIT1"],
+            "testing": ["UNIT1"],
+            "balance": {}
+        },
+        "slice_filter_params": {
+            "filter_empty_mask": true,
+            "filter_empty_input": true
+        },
+        "slice_axis": "axial",
+        "multichannel": false,
+        "soft_gt": false
+    },
+    "split_dataset": {
+        "fname_split": null,
+        "random_seed": 42,
+        "center_test": [],
+        "method": "per_patient",
+        "balance": null,
+        "train_fraction": 0.75,
+        "test_fraction": 0.2
+    },
+    "uncertainty": {
+        "epistemic": false,
+        "aleatoric": false,
+        "n_it": 0
+    },
+    "postprocessing": {"binarize_prediction": {"thr": 0.5}},
+    "evaluation_parameters": {},
+    "transformation": {
+        "Resample": {
+            "wspace": 1.0,
+            "hspace": 1.0,
+            "dspace": 1.0
+        },
+        "CenterCrop": {
+            "size": [64, 128, 32]
+        },
+        "NumpyToTensor": {},
+        "NormalizeInstance": {
+            "applied_to": ["im"]
+        }
+    },
+    "Modified3DUNet": {
+        "applied": true,
+        "length_3D": [64, 128, 32],
+        "stride_3D": [64, 128, 32],
+        "attention": false,
+        "n_filters": 8
+    }
+}


### PR DESCRIPTION
This PR adds the ivadomed config file `cascaded.json` for running inference on a cascaded pipeline as mentioned in #9. 

To Reproduce
----

**0. Make sure you have the following dependencies:**
* `sct`=5.4.0
* `ivadomed`=(git-master-1d81b32c61891e4b5b4f2ffbbb7923e367111dc9*)

**1. Clone the repository:** 
```
git clone https://github.com/ivadomed/model_seg_ms_mp2rage.git
cd model_seg_ms_mp2rage
```
**2. Clone the latest version of the data:**
```
git clone git@data.neuro.polymtl.ca:datasets/basel-mp2rage
cd basel-mp2rage
git annex get .
cd ..
```
**3. Preprocess the data:**
```
sct_run_batch -script preprocessing/preprocess_data.sh -path-data basel-mp2rage -path-output basel-mp2rage-preprocessed-lesionseg -script-args "svm lesionseg" -jobs <JOBS>
``` 
**4. Run inference wit the cascaded pipeline:**
```
git checkout um/ivadomed_cascaded_pipeline
ivadomed --test -c config/cascaded.json
```