### PR TITLE
Updated README with reproducibility steps and latest syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ivadomed --train -c config/seg_lesion.json
 
 ## Get trained models
 
-```console
+```
 cp -r ~/duke/temp/uzay/saved_models_basel/seg_sc_output .
 cp -r ~/duke/temp/uzay/saved_models_basel/seg_lesion_output .
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ git clone https://github.com/ivadomed/model_seg_ms_mp2rage.git
 
 - git@data.neuro.polymtl.ca:datasets/basel-mp2rage
 - Commit: 93110d8ebb65398dcc6e4528bf548eb7828332f1
+
+### Example calls to get the data
+
+~~~
+git clone git@data.neuro.polymtl.ca:datasets/basel-mp2rage
+cd basel-mp2rage
+git annex get .
+cd ..
+~~~
  
 ## Prepare the data
 
@@ -27,12 +36,12 @@ sct_run_batch -script <PATH_TO_REPOSITORY>/preprocessing/preprocess_data.sh -pat
 ~~~
 
 This command will create a `data_processed_scseg` folder for the SC segmentation task and a 
-`data_processed_lesionseg` folder for the lesion segmentation task inside the `<PATH_OUTPUT>` 
+`data_processed_lesionseg` folder for the lesion segmentation task inside the `basel-mp2rage-preprocessed` 
 you specified. Each of these two folders contain only the required files for their respective task.
 
 After running the preprocessing, you can also run the quality-control (QC) script:
 ```
-python preprocessing/qc_preprocess.py -s <PATH_OUTPUT>
+python preprocessing/qc_preprocess.py -s basel-mp2rage-preprocessed
 ```
 which i) logs resolutions and sizes for each subject image (both raw and cropped) for data exploration, 
 ii) performs basic shape checks for spinal cord (SC) cropped images and ground-truths (GTs), and 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Model repository for MS lesion segmentation on MP2RAGE data as discussed in http
 ## Dependencies
 
 - [SCT](https://spinalcordtoolbox.com/) commit: 7fd2ea718751dd858840c3823c0830a910d9777c
-- [ivadomed](https://ivadomed.org) commit: XXX
+- [ivadomed](https://ivadomed.org) commit: git-master-93ba03df76d229d8a190c694f757da6c00efa545
 
 ## Clone this repository
 
@@ -15,15 +15,15 @@ git clone https://github.com/ivadomed/model_seg_ms_mp2rage.git
 
 ## Get the data
 
-- data.neuro.polymtl.ca:basel-mp2rage
-- Commit: 88c506eb9855d6a0cb29a2e95c3283b8fd0a8099
+- git@data.neuro.polymtl.ca:datasets/basel-mp2rage
+- Commit: 93110d8ebb65398dcc6e4528bf548eb7828332f1
  
 ## Prepare the data
 
 The data need to be preprocessed before training. The preprocessing command is:
 
 ~~~
-sct_run_batch -script <PATH_TO_REPOSITORY>/preprocessing/preprocess_data.sh -path-data <PATH_TO_DATA>/basel-mp2rage/ -path-output <PATH_OUTPUT> -jobs <JOBS>
+sct_run_batch -script <PATH_TO_REPOSITORY>/preprocessing/preprocess_data.sh -path-data <PATH_TO_DATA>/basel-mp2rage/ -path-output basel-mp2rage-preprocessed -jobs <JOBS>
 ~~~
 
 This command will create a `data_processed_scseg` folder for the SC segmentation task and a 
@@ -34,6 +34,50 @@ After running the preprocessing, you can also run the quality-control (QC) scrip
 ```
 python preprocessing/qc_preprocess.py -s <PATH_OUTPUT>
 ```
-which i) logs resolutions and sizes for each SC-cropped subject image for data exploration, 
-ii) performs basic shape checks for SC-cropped images and ground-truths (GTs), and most importantly 
-iii) checks if the dilated spinal-cord (SC) mask leaves out any lesions from the GT of each rater.
+which i) logs resolutions and sizes for each subject image (both raw and cropped) for data exploration, 
+ii) performs basic shape checks for spinal cord (SC) cropped images and ground-truths (GTs), and 
+most importantly iii) checks if the dilated SC mask leaves out any lesions from the GT of each rater.
+
+## Training
+
+Spinal cord segmentation training was carried out with
+```
+ivadomed --train -c config/seg_sc.json
+```
+
+Lesion segmentation training was carried out with
+```
+ivadomed --train -c config/seg_lesion.json
+```
+
+## Get trained models
+
+```console
+cp -r ~/duke/temp/uzay/saved_models_basel/seg_sc_output .
+cp -r ~/duke/temp/uzay/saved_models_basel/seg_lesion_output .
+```
+
+## Performance evaluation
+
+To test a spinal cord segmentation model run
+```
+ivadomed --test -c config/seg_sc.json
+```
+
+To test a lesion segmentation model independently on the two rater's annotations
+```
+ivadomed --test -c config/test_on_rater1.json
+ivadomed --test -c config/test_on_rater2.json
+```
+
+## Segment a dataset
+
+To run inference with spinal cord segmentation model on a dataset run
+```
+ivadomed --segment -c config/seg_sc.json --path-data <PATH_DATA>
+```
+
+To run inference with lesion segmentation model on a dataset run
+```
+ivadomed --segment -c config/seg_lesion.json --path-data <PATH_DATA>
+```


### PR DESCRIPTION
This PR fixes #30 by
* updates `ivadomed` and data versions
* updates preprocessing syntax to be compatible with the config files provided (inside `config/`)
* add instructions for (a) how to train models from scratch, (b) how to acquire trained models, (c) how to test the models, and (d) how to segment an entire dataset with 

TODO:
- [x] Update `ivadomed` version once PRs for (i) random bias field, (ii) random blur are implemented.