### PR TITLE
Removed comments for args for task and centerline

### DIFF
--- a/preprocessing/preprocess_data.sh
+++ b/preprocessing/preprocess_data.sh
@@ -6,11 +6,9 @@
 # - SCT (5.4.0)
 #
 # Usage:
-#   ./preprocess_data.sh <SUBJECT> <CENTERLINE_METHOD> <TASK>
+#   ./preprocess_data.sh <SUBJECT>
 #
 # <SUBJECT> is the name of the subject in BIDS convention (sub-XXX)
-# <CENTERLINE_METHOD> is the method sct_deepseg_sc uses for centerline extraction (cnn or svm)
-# <TASK> is the aimed training task which will guide preprocessing (scseg or lesionseg)
 #
 # Manual segmentations or labels should be located under:
 # PATH_DATA/derivatives/labels/SUBJECT/<CONTRAST>/


### PR DESCRIPTION
This PR fixes #36 by removing comments for task and centerline args in the `preprocessing/preprocess_data.sh` script as these are no longer needed from the user.