### PR TITLE
Script for benchmarking of SC and lesion segmentation

### DIFF
--- a/benchmark.md
+++ b/benchmark.md
@@ -1,0 +1,109 @@
+# Benchmarking
+
+This file documents benchmarking done on models for (i) SC segmentation and (ii) lesion segmentation on MP2RAGE data.
+This will help with presenting experiment results, tracking the performance
+of the deployed models, and act as a reference for future projects.
+
+The test subjects used in benchmarking are `sub-P007`, `sub-P010`, `sub-P013`, `sub-P017`, `sub-P024`, and `sub-P025`. 
+
+## SC segmentation
+
+### Currently deployed model
+As previously shown in [#19](https://github.com/ivadomed/model_seg_ms_mp2rage/pull/19), the currently
+deployed SC segmentation model achieves a test Dice score of 0.9511.
+
+### Subject-by-subject comparison vs. `sct_deepseg_sc`
+
+```console
+SC Segmentation Benchmarking
+-------------------------------------------------
+        Subject:  sub-P013
+        SC Model Dice Score:  -0.9512
+        SCT (sct_deepseg_sc) Dice Score:  -0.9847
+        -------------------------------
+        Subject:  sub-P024
+        SC Model Dice Score:  -0.9511
+        SCT (sct_deepseg_sc) Dice Score:  -0.9764
+        -------------------------------
+        Subject:  sub-P007
+        SC Model Dice Score:  -0.9551
+        SCT (sct_deepseg_sc) Dice Score:  -0.9699
+        -------------------------------
+        Subject:  sub-P017
+        SC Model Dice Score:  -0.9492
+        SCT (sct_deepseg_sc) Dice Score:  -0.9917
+        -------------------------------
+```
+
+More detail on this analysis can be found in [#40](https://github.com/ivadomed/model_seg_ms_mp2rage/pull/40).
+
+## Lesion segmentation
+
+### Currently deployed model
+The currently deployed lesion segmentation model achieves a test Dice score of 
+0.5549 on the first rater annotations and 0.6115 on the second rater annotations.
+This is different from the results reported in [#11](https://github.com/ivadomed/model_seg_ms_mp2rage/pull/11)
+due to a derivative loading bug recently discovered in `ivadomed` as detailed in [#41](https://github.com/ivadomed/model_seg_ms_mp2rage/issues/41).
+
+### Subject-by-subject comparison vs. `sct_deepseg_lesion`
+
+```console
+Lesion Segmentation Benchmarking
+-------------------------------------------------
+        Subject:  sub-P013
+        Lesion Model Dice Score (Rater 1):  -0.4929
+        Lesion Model Dice Score (Rater 2):  -0.5588
+        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.0017
+        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0215
+        -------------------------------
+        Subject:  sub-P024
+        Lesion Model Dice Score (Rater 1):  -0.4551
+        Lesion Model Dice Score (Rater 2):  -0.5891
+        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.0023
+        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0014
+        -------------------------------
+        Subject:  sub-P007
+        Lesion Model Dice Score (Rater 1):  -0.4649
+        Lesion Model Dice Score (Rater 2):  -0.5302
+        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.006
+        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0038
+        -------------------------------
+        Subject:  sub-P025
+        Lesion Model Dice Score (Rater 1):  -0.6126
+        Lesion Model Dice Score (Rater 2):  -0.7069
+        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.0055
+        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0059
+        -------------------------------
+        Subject:  sub-P017
+        Lesion Model Dice Score (Rater 1):  -1.0
+        Lesion Model Dice Score (Rater 2):  -1.0
+        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -1.0
+        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -1.0
+        -------------------------------
+        Subject:  sub-P010
+        Lesion Model Dice Score (Rater 1):  -0.749
+        Lesion Model Dice Score (Rater 2):  -0.6726
+        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.0017
+        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0039
+        -------------------------------
+```
+More detail on this analysis can be found in [#40](https://github.com/ivadomed/model_seg_ms_mp2rage/pull/40).
+
+### Experiments
+
+All of the models mentioned below were trained and tested for `4` independent trials. The mean +/-
+standard deviation test performance is shown in the table.
+
+| Config      | Labels used | Label utilization | Test Dice (Rater 1) | Test Dice (Rater 2) |
+| ----------- | ----------- | ----------------- | ------------------- | ------------------- |
+| `softseg`   | soft average | n/a | -0.5306 +/- 0.1069 | -0.5968 +/- 0.0771 |
+| `multiclass` | both raters | each rater a separate class | -0.5355 +/- 0.1340 | -0.6051 +/- 0.0764 |
+| `multiclass` + `softseg` | both raters | each rater a separate class | -0.5301 +/- 0.1385 | -0.6215 +/- 0.0737 |
+| `randomrater` | both raters | randomly pick rater in each iter | -0.5734 +/- 0.1132 | -0.5897 +/- 0.1115 |
+| `randomrater` + `softseg` | both raters | randomly pick rater in each iter | -0.5507 +/- 0.1230 | -0.6015 +/- 0.1074 |
+| `randomrater` + `mix-up (alpha=1.0)` | both raters | randomly pick rater in each iter | -0.4720 +/- 0.1239 | -0.5342 +/- 0.1064 |
+| `randomrater++` | both raters, soft average, majority-vote | randomly pick label in each iter | -0.5784 +/- 0.0797 | -0.5543 +/- 0.1110 |
+| `randomrater++` + `softseg` | both raters, soft average, majority-vote | randomly pick label in each iter | -0.5625 +/- 0.1278 | -0.6091 +/- 0.0905
+| `firstrater` | first rater | n/a | -0.5409 +/- 0.1272 | -0.5491 +/- 0.1214 |
+| `secondrater` | first rater | n/a | -0.5011 +/- 0.1646 | -0.6011 +/- 0.0943 |
+

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,158 @@
+import os
+import shutil
+import json
+from subprocess import call, DEVNULL, STDOUT
+import nibabel as nib
+from ivadomed.losses import DiceLoss
+
+# Initialize Dice loss for running evaluation
+dice_loss = DiceLoss(smooth=1.0)
+
+# Generate output paths
+output_path = 'benchmark_output'
+sc_output_path = os.path.join(output_path, 'sc')
+lesion_output_path = os.path.join(output_path, 'lesion')
+print('The prediction images used in benchmarking can be found in `%s` and `%s`!' % (sc_output_path, lesion_output_path))
+if not os.path.exists(output_path):
+    os.makedirs(output_path)
+    os.makedirs(sc_output_path)
+    os.makedirs(lesion_output_path)
+
+# Set paths for data, config, and model for (i) SC segmentation and (ii) lesion segmentation
+sc_data_path = '../basel-mp2rage-preprocessed/data_processed_scseg'
+lesion_data_path = '../basel-mp2rage-preprocessed/data_processed_lesionseg'
+sc_config_path = '../config/seg_sc.json'
+lesion_config_path = '../config/test_on_rater1.json'
+# NOTE: Used `test_on_rater1.json` instead of `seg_lesion.json` to provide one target suffix
+sc_model_path = '../seg_sc_output'
+lesion_model_path = '../seg_lesion_output'
+
+# Basic checks to ensure paths exist
+paths = [sc_data_path, lesion_data_path, sc_config_path, lesion_config_path, sc_model_path, lesion_model_path]
+assert all([os.path.exists(path) for path in paths])
+
+# Get prediction paths for both models
+sc_predictions_path = os.path.join(sc_model_path, 'pred_masks')
+lesion_predictions_path = os.path.join(lesion_model_path, 'pred_masks')
+
+# Clear all predictions from before if applicable
+if os.path.exists(sc_predictions_path):
+    print('Removing previous predictions from `pred_masks` for SC segmentation!')
+    for f in os.listdir(sc_predictions_path):
+        os.remove(os.path.join(sc_predictions_path, f))
+if os.path.exists(lesion_predictions_path):
+    print('Removing previous predictions from `pred_masks` for lesion segmentation!')
+    for f in os.listdir(lesion_predictions_path):
+        os.remove(os.path.join(lesion_predictions_path, f))
+
+# Run testing on both models to generate prediction files
+call(
+    ['ivadomed', '--test', '-c', sc_config_path, '-po', sc_model_path, '-pd', sc_data_path],
+    stdout=DEVNULL,
+    stderr=STDOUT
+)
+call(
+    ['ivadomed', '--test', '-c', lesion_config_path, '-po', lesion_model_path, '-pd', lesion_data_path],
+    stdout=DEVNULL,
+    stderr=STDOUT
+)
+
+# Iterate through SC predictions
+print('\nSC Segmentation Benchmarking')
+print('-------------------------------------------------')
+for f in os.listdir(sc_predictions_path):
+    # Skip painted prediction images
+    if f.endswith('_painted.nii.gz'):
+        continue
+
+    # Get subject, label and JSON path information for SC segmentation
+    subject = f.split('_')[0]
+    label_path = os.path.join(sc_data_path, 'derivatives', 'labels', subject, 'anat')
+    json_path = os.path.join(label_path, '%s_UNIT1_seg-manual.json' % subject)
+
+    # Skip subject if non-corrected SC annotation (i.e. generated with sct_deepseg_sc)
+    with open(json_path) as f_:
+        author = json.load(f_)['Author']
+        if author == "Generated with sct_deepseg_sc":
+            print('Skipping subject=%s due to non-corrected SC segmentation!' % subject)
+            continue
+
+    # Get image and GT path for SC segmentation
+    img_path = os.path.join(sc_data_path, subject, 'anat', '%s_UNIT1.nii.gz' % subject)
+    gt_path = os.path.join(label_path, '%s_UNIT1_seg-manual.nii.gz' % subject)
+
+    # Copy image, GT, and model predictions to the relevant benchmark output path
+    shutil.copy(img_path, os.path.join(sc_output_path, '%s_UNIT1.nii.gz' % subject))
+    shutil.copy(gt_path, os.path.join(sc_output_path, '%s_UNIT1_seg-manual.nii.gz' % subject))
+    shutil.copy(os.path.join(sc_predictions_path, f), os.path.join(sc_output_path, f))
+
+    # Load GT and model prediction for SC segmentation as NumPy arrays
+    gt = nib.load(gt_path).get_fdata()
+    model_prediction = nib.load(os.path.join(sc_predictions_path, f)).get_fdata()[:, :, :, 0]
+
+    # Use sct_deepseg_sc to generate an alternative SC segmentation to compare the model to
+    sct_prediction_path = os.path.join(sc_output_path, '%s_sct_deepseg_sc.nii.gz' % subject)
+    call(
+        ['sct_deepseg_sc', '-i', img_path, '-c', 't1', '-centerline', 'svm', '-o', sct_prediction_path],
+        stdout=DEVNULL,
+        stderr=STDOUT
+    )
+    sct_prediction = nib.load(sct_prediction_path).get_fdata()
+
+    # Basic shape check for the predictions
+    assert gt.shape == model_prediction.shape == sct_prediction.shape
+
+    # Print basic evaluation scores
+    print('\tSubject: ', subject)
+    print('\tSC Model Dice Score: ', round(dice_loss(model_prediction, gt), 4))
+    print('\tSCT (sct_deepseg_sc) Dice Score: ', round(dice_loss(sct_prediction, gt), 4))
+    print('\t-------------------------------')
+
+# Iterate through lesion predictions
+print('\nLesion Segmentation Benchmarking')
+print('-------------------------------------------------')
+for f in os.listdir(lesion_predictions_path):
+    # Skip painted prediction images
+    if f.endswith('_painted.nii.gz'):
+        continue
+
+    # Get subject, label and JSON path information for lesion segmentation
+    subject = f.split('_')[0]
+    label_path = os.path.join(lesion_data_path, 'derivatives', 'labels', subject, 'anat')
+
+    # Get image and GT paths for lesion segmentation
+    img_path = os.path.join(lesion_data_path, subject, 'anat', '%s_UNIT1.nii.gz' % subject)
+    gt1_path = os.path.join(label_path, '%s_UNIT1_lesion-manual.nii.gz' % subject)
+    gt2_path = os.path.join(label_path, '%s_UNIT1_lesion-manual2.nii.gz' % subject)
+
+    # Copy image, GTs, and model predictions to the relevant benchmark output path
+    shutil.copy(img_path, os.path.join(lesion_output_path, '%s_UNIT1.nii.gz' % subject))
+    shutil.copy(gt1_path, os.path.join(lesion_output_path, '%s_UNIT1_lesion-manual.nii.gz' % subject))
+    shutil.copy(gt2_path, os.path.join(lesion_output_path, '%s_UNIT1_lesion-manual2.nii.gz' % subject))
+    shutil.copy(os.path.join(lesion_predictions_path, f), os.path.join(lesion_output_path, f))
+
+    # Load GTs and model prediction for lesion segmentation as NumPy arrays
+    gt1 = nib.load(gt1_path).get_fdata()
+    gt2 = nib.load(gt2_path).get_fdata()
+    model_prediction = nib.load(os.path.join(lesion_predictions_path, f)).get_fdata()[:, :, :, 0]
+
+    # Use sct_deepseg_lesion to generate an alternative lesion segmentation to compare the model to
+    sct_prediction_path = os.path.join(lesion_output_path, '%s_sct_deepseg_lesion.nii.gz' % subject)
+    call(
+        ['sct_deepseg_lesion', '-i', img_path, '-c', 't2', '-centerline', 'svm', '-ofolder', lesion_output_path],
+        stdout=DEVNULL,
+        stderr=STDOUT
+    )
+    os.rename(os.path.join(lesion_output_path, '%s_UNIT1_lesionseg.nii.gz' % subject), sct_prediction_path)
+    sct_prediction = nib.load(sct_prediction_path).get_fdata()
+
+    # Basic shape check for the predictions
+    assert gt1.shape == gt2.shape == model_prediction.shape == sct_prediction.shape
+
+    # Print basic evaluation scores
+    print('\tSubject: ', subject)
+    print('\tLesion Model Dice Score (Rater 1): ', round(dice_loss(model_prediction, gt1), 4))
+    print('\tLesion Model Dice Score (Rater 2): ', round(dice_loss(model_prediction, gt2), 4))
+    print('\tSCT (sct_deepseg_lesion) Dice Score (Rater 1): ', round(dice_loss(sct_prediction, gt1), 4))
+    print('\tSCT (sct_deepseg_lesion) Dice Score (Rater 2): ', round(dice_loss(sct_prediction, gt2), 4))
+    print('\t-------------------------------')


### PR DESCRIPTION
This PR resolves #39 and resolves #28 by introducing the script `scripts/benchmark.py` which
* runs testing for SC segmentation and lesion segmentation
* compares `sct_deepseg_sc` to the newly trained `ivadomed` SC segmentation model
* compares `sct_deepseg_lesion` to the newly trained `ivadomed` lesion segmentation model
* copies the relevant files (e.g. images, annotations, and prediction) to an output folder `scripts/benchmark_output`

The script is run as shown below (example outputs are also shown below):

```console
(um_main) uzmac@romane:~/model_seg_ms_mp2rage/scripts$ python benchmark.py 
The prediction images used in benchmarking can be found in `benchmark_output/sc` and `benchmark_output/lesion`!
Removing previous predictions from `pred_masks` for SC segmentation!
Removing previous predictions from `pred_masks` for lesion segmentation!

SC Segmentation Benchmarking
-------------------------------------------------
        Subject:  sub-P013
        SC Model Dice Score:  -0.9512
        SCT (sct_deepseg_sc) Dice Score:  -0.9847
        -------------------------------
        Subject:  sub-P024
        SC Model Dice Score:  -0.9511
        SCT (sct_deepseg_sc) Dice Score:  -0.9764
        -------------------------------
        Subject:  sub-P007
        SC Model Dice Score:  -0.9551
        SCT (sct_deepseg_sc) Dice Score:  -0.9699
        -------------------------------
Skipping subject=sub-P025 due to non-corrected SC segmentation!
        Subject:  sub-P017
        SC Model Dice Score:  -0.9492
        SCT (sct_deepseg_sc) Dice Score:  -0.9917
        -------------------------------
Skipping subject=sub-P010 due to non-corrected SC segmentation!

Lesion Segmentation Benchmarking
-------------------------------------------------
        Subject:  sub-P013
        Lesion Model Dice Score (Rater 1):  -0.4929
        Lesion Model Dice Score (Rater 2):  -0.5588
        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.0017
        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0215
        -------------------------------
        Subject:  sub-P024
        Lesion Model Dice Score (Rater 1):  -0.4551
        Lesion Model Dice Score (Rater 2):  -0.5891
        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.0023
        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0014
        -------------------------------
        Subject:  sub-P007
        Lesion Model Dice Score (Rater 1):  -0.4649
        Lesion Model Dice Score (Rater 2):  -0.5302
        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.006
        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0038
        -------------------------------
        Subject:  sub-P025
        Lesion Model Dice Score (Rater 1):  -0.6126
        Lesion Model Dice Score (Rater 2):  -0.7069
        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.0055
        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0059
        -------------------------------
        Subject:  sub-P017
        Lesion Model Dice Score (Rater 1):  -1.0
        Lesion Model Dice Score (Rater 2):  -1.0
        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -1.0
        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -1.0
        -------------------------------
        Subject:  sub-P010
        Lesion Model Dice Score (Rater 1):  -0.749
        Lesion Model Dice Score (Rater 2):  -0.6726
        SCT (sct_deepseg_lesion) Dice Score (Rater 1):  -0.0017
        SCT (sct_deepseg_lesion) Dice Score (Rater 2):  -0.0039
        -------------------------------
(um_main) uzmac@romane:~/model_seg_ms_mp2rage/scripts$ 
```

**The benchmark output folder (`scripts/benchmark_output`) that is generated as a result of this script can be further investigated to visually assess the performance of the two models**. 

Below, we give an example visualization of test subject `sub-P007` for SC segmentation and lesion segmentation.

### SC Segmentation

![sc_benchmark_example](https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20211223/sc_benchmark_example.gif)

### Lesion Segmentation

![lesion_benchmark_example](https://github.com/ivadomed/model_seg_ms_mp2rage/releases/download/r20211223/lesion_benchmark_example.gif)