### PR TITLE
Fixed target suffix in config files for loading correct derivatives

### DIFF
--- a/config/seg_lesion.json
+++ b/config/seg_lesion.json
@@ -15,7 +15,7 @@
             "metadata": [],
             "value": []
         },
-        "target_suffix": [["_lesion-manual", "_lesion-manual2"]],
+        "target_suffix": [["_lesion-manual.nii.gz", "_lesion-manual2.nii.gz"]],
         "extensions": [],
         "roi_params": {
             "suffix": null,

--- a/config/seg_sc.json
+++ b/config/seg_sc.json
@@ -15,7 +15,7 @@
             "metadata": [],
             "value": []
         },
-        "target_suffix": ["_seg-manual"],
+        "target_suffix": ["_seg-manual.nii.gz"],
         "extensions": [],
         "roi_params": {
             "suffix": null,

--- a/config/test_on_rater1.json
+++ b/config/test_on_rater1.json
@@ -15,7 +15,7 @@
             "metadata": [],
             "value": []
         },
-        "target_suffix": ["_lesion-manual"],
+        "target_suffix": ["_lesion-manual.nii.gz"],
         "extensions": [],
         "roi_params": {
             "suffix": null,

--- a/config/test_on_rater2.json
+++ b/config/test_on_rater2.json
@@ -15,7 +15,7 @@
             "metadata": [],
             "value": []
         },
-        "target_suffix": ["_lesion-manual2"],
+        "target_suffix": ["_lesion-manual2.nii.gz"],
         "extensions": [],
         "roi_params": {
             "suffix": null,


### PR DESCRIPTION
This PR resolves #41 by adding `.nii.gz` extension to all target suffixes across the four config files in order to load the correct derivatives. As discussed in [ivadomed/ivadomed#1055](https://github.com/ivadomed/ivadomed/issues/1055), there was previously a bug in the loading of derivatives in this project due to the use of `contains()` during the loading process implemented in `ivadomed/loader/bids_dataframe.py`.

The fixed target suffix for lesion segmentation in this PR implements the randomly picking one of the two raters in each iteration strategy as before. This is because, as per the results presented in #40 through the `benchmark.md` file, this strategy achieves good Dice scores on both raters when compared to the other strategies.

However, if we implement the [first option I presented here](https://github.com/ivadomed/ivadomed/issues/1055#issue-1114505527) to take care of [ivadomed/ivadomed#1055](https://github.com/ivadomed/ivadomed/issues/1055), then we might safely revert this PR as there will be no need for `.nii.gz` extension due to the enforcing of an exact match. (Further discussion with the ivadomed team is required to reach a decision, which will affect this PR.)